### PR TITLE
Support Regex flags (i.e. case insensitivity) and refactor code to use single `regex.ex` file

### DIFF
--- a/lib/rewizard/cogs/find.ex
+++ b/lib/rewizard/cogs/find.ex
@@ -30,7 +30,7 @@ defmodule Rewizard.Cogs.Find do
   def find(str_regex, flags, target) do
     res =
       with {:ok, regex} <- Rewizard.Regex.compile(str_regex, flags),
-           {:ok, result} <- Rewizard.Regex.find(regex, target, capture: :first),
+           {:ok, result} <- Rewizard.Regex.find(regex, target),
            do: success(regex, target, result)
 
     case res do

--- a/lib/rewizard/cogs/find.ex
+++ b/lib/rewizard/cogs/find.ex
@@ -2,8 +2,8 @@ defmodule Rewizard.Cogs.Find do
   @behaviour Nosedrum.Command
 
   alias Nostrum.Api
-  alias Nostrum.Struct.Embed
   import Nostrum.Struct.Embed
+  alias Rewizard.Embeds
 
   @impl true
   def usage, do: ["find <regex> <target>", "find <regex> <flags> <target>"]
@@ -15,20 +15,16 @@ defmodule Rewizard.Cogs.Find do
   def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
 
   def success(regex, target, result) do
-    %Embed{}
-    |> put_title("Rewizard - Find")
-    |> put_color(0x008000)
-    |> put_field("Regex", Rewizard.Regex.source(regex))
-    |> put_field("Target", "`#{target}`")
-    |> put_field("Result", "`#{inspect(result)}`")
+    Embeds.success("Find")
+      |> Embeds.regex(regex)
+      |> put_field("Target", "`#{target}`")
+      |> put_field("Result", "`#{inspect(result)}`")
   end
 
-  def failed(strRegex, message) do
-    %Embed{}
-    |> put_title("Rewizard - Find")
-    |> put_color(0xFF0000)
-    |> put_field("Regex", strRegex)
-    |> put_field("Error", message)
+  def failed(tpl_regex, message) do
+    Embeds.fail("Find")
+      |> Embeds.regex(tpl_regex)
+      |> put_field("Error", message)
   end
 
   def find(strRegex, flags, target) do

--- a/lib/rewizard/cogs/find.ex
+++ b/lib/rewizard/cogs/find.ex
@@ -16,26 +16,26 @@ defmodule Rewizard.Cogs.Find do
 
   def success(regex, target, result) do
     Embeds.success("Find")
-      |> Embeds.regex(regex)
-      |> put_field("Target", "`#{target}`")
-      |> put_field("Result", "`#{inspect(result)}`")
+    |> Embeds.regex(regex)
+    |> put_field("Target", "`#{target}`")
+    |> put_field("Result", "`#{inspect(result)}`")
   end
 
   def failed(tpl_regex, message) do
     Embeds.fail("Find")
-      |> Embeds.regex(tpl_regex)
-      |> put_field("Error", message)
+    |> Embeds.regex(tpl_regex)
+    |> put_field("Error", message)
   end
 
-  def find(strRegex, flags, target) do
+  def find(str_regex, flags, target) do
     res =
-      with {:ok, regex} <- Rewizard.Regex.compile(strRegex, flags),
+      with {:ok, regex} <- Rewizard.Regex.compile(str_regex, flags),
            {:ok, result} <- Rewizard.Regex.find(regex, target, capture: :first),
            do: success(regex, target, result)
 
     case res do
-      {:error, strRegex, msg} ->
-        failed(strRegex, msg)
+      {:error, str_regex, msg} ->
+        failed(str_regex, msg)
 
       {:fail, regex, msg} ->
         failed(Rewizard.Regex.source(regex), msg)
@@ -46,14 +46,14 @@ defmodule Rewizard.Cogs.Find do
   end
 
   @impl true
-  def command(msg, [strRegex, target]) do
-    reply = find(strRegex, "", target)
+  def command(msg, [str_regex, target]) do
+    reply = find(str_regex, "", target)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 
   @impl true
-  def command(msg, [strRegex, flags, target]) do
-    reply = find(strRegex, flags, target)
+  def command(msg, [str_regex, flags, target]) do
+    reply = find(str_regex, flags, target)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 end

--- a/lib/rewizard/cogs/find.ex
+++ b/lib/rewizard/cogs/find.ex
@@ -6,7 +6,7 @@ defmodule Rewizard.Cogs.Find do
   import Nostrum.Struct.Embed
 
   @impl true
-  def usage, do: ["find <regex> <target>"]
+  def usage, do: ["find <regex> <target>", "find <regex> <flags> <target>"]
 
   @impl true
   def description, do: "Find this regex in that target."
@@ -14,44 +14,50 @@ defmodule Rewizard.Cogs.Find do
   @impl true
   def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
 
-  def failed(regex, message) do
-    %Embed{}
-    |> put_title("Rewizard - Find")
-    |> put_color(0xFF0000)
-    |> put_field("Regex", "`#{regex}`")
-    |> put_field("Error", message)
-  end
-
   def success(regex, target, result) do
     %Embed{}
     |> put_title("Rewizard - Find")
     |> put_color(0x008000)
-    |> put_field("Regex", "`#{Regex.source(regex)}`")
+    |> put_field("Regex", Rewizard.Regex.source(regex))
     |> put_field("Target", "`#{target}`")
     |> put_field("Result", "`#{inspect(result)}`")
   end
 
-  def find(regex, target) do
-    case Regex.run(regex, target, capture: :first) do
-      nil -> failed(regex, "Didn't find anything.")
-      result -> success(regex, target, result)
+  def failed(strRegex, message) do
+    %Embed{}
+    |> put_title("Rewizard - Find")
+    |> put_color(0xFF0000)
+    |> put_field("Regex", strRegex)
+    |> put_field("Error", message)
+  end
+
+  def find(strRegex, flags, target) do
+    res =
+      with {:ok, regex} <- Rewizard.Regex.compile(strRegex, flags),
+           {:ok, result} <- Rewizard.Regex.find(regex, target, capture: :first),
+           do: success(regex, target, result)
+
+    case res do
+      {:error, strRegex, msg} ->
+        failed(strRegex, msg)
+
+      {:fail, regex, msg} ->
+        failed(Rewizard.Regex.source(regex), msg)
+
+      _ ->
+        res
     end
   end
 
   @impl true
-  def command(msg, [regex, target]) do
-    reply =
-      case Regex.compile(regex) do
-        {:ok, regex} ->
-          find(regex, target)
+  def command(msg, [strRegex, target]) do
+    reply = find(strRegex, "", target)
+    Api.create_message!(msg.channel_id, embed: reply)
+  end
 
-        {:error, {error, location}} ->
-          failed(
-            regex,
-            "Failed to parse regex at location #{location} with error #{inspect(error)}"
-          )
-      end
-
+  @impl true
+  def command(msg, [strRegex, flags, target]) do
+    reply = find(strRegex, flags, target)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 end

--- a/lib/rewizard/cogs/find_all.ex
+++ b/lib/rewizard/cogs/find_all.ex
@@ -2,8 +2,8 @@ defmodule Rewizard.Cogs.FindAll do
   @behaviour Nosedrum.Command
 
   alias Nostrum.Api
-  alias Nostrum.Struct.Embed
   import Nostrum.Struct.Embed
+  alias Rewizard.Embeds
 
   @impl true
   def usage, do: ["find_all <regex> <target>", "find_all <regex> <flags> <target>"]
@@ -15,20 +15,16 @@ defmodule Rewizard.Cogs.FindAll do
   def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
 
   def success(regex, target, result) do
-    %Embed{}
-    |> put_title("Rewizard - Find All")
-    |> put_color(0x008000)
-    |> put_field("Regex", Rewizard.Regex.source(regex))
-    |> put_field("Target", "`#{target}`")
-    |> put_field("Result", "`#{inspect(result)}`")
+    Embeds.success("Find All")
+      |> Embeds.regex(regex)
+      |> put_field("Target", "`#{target}`")
+      |> put_field("Result", "`#{inspect(result)}`")
   end
 
-  def failed(regex, message) do
-    %Embed{}
-    |> put_title("Rewizard - Find All")
-    |> put_color(0xFF0000)
-    |> put_field("Regex", "`#{regex}`")
-    |> put_field("Error", message)
+  def failed(tpl_regex, message) do
+    Embeds.fail("Find All")
+      |> Embeds.regex(tpl_regex)
+      |> put_field("Error", message)
   end
 
   def find(strRegex, flags, target) do

--- a/lib/rewizard/cogs/find_all.ex
+++ b/lib/rewizard/cogs/find_all.ex
@@ -30,7 +30,7 @@ defmodule Rewizard.Cogs.FindAll do
   def find(str_regex, flags, target) do
     res =
       with {:ok, regex} <- Rewizard.Regex.compile(str_regex, flags),
-           {:ok, result} <- Rewizard.Regex.find(regex, target, []),
+           {:ok, result} <- Rewizard.Regex.find_all(regex, target),
            do: success(regex, target, result)
 
     case res do

--- a/lib/rewizard/cogs/find_all.ex
+++ b/lib/rewizard/cogs/find_all.ex
@@ -16,26 +16,26 @@ defmodule Rewizard.Cogs.FindAll do
 
   def success(regex, target, result) do
     Embeds.success("Find All")
-      |> Embeds.regex(regex)
-      |> put_field("Target", "`#{target}`")
-      |> put_field("Result", "`#{inspect(result)}`")
+    |> Embeds.regex(regex)
+    |> put_field("Target", "`#{target}`")
+    |> put_field("Result", "`#{inspect(result)}`")
   end
 
   def failed(tpl_regex, message) do
     Embeds.fail("Find All")
-      |> Embeds.regex(tpl_regex)
-      |> put_field("Error", message)
+    |> Embeds.regex(tpl_regex)
+    |> put_field("Error", message)
   end
 
-  def find(strRegex, flags, target) do
+  def find(str_regex, flags, target) do
     res =
-      with {:ok, regex} <- Rewizard.Regex.compile(strRegex, flags),
+      with {:ok, regex} <- Rewizard.Regex.compile(str_regex, flags),
            {:ok, result} <- Rewizard.Regex.find(regex, target, []),
            do: success(regex, target, result)
 
     case res do
-      {:error, strRegex, msg} ->
-        failed(strRegex, msg)
+      {:error, str_regex, msg} ->
+        failed(str_regex, msg)
 
       {:fail, regex, msg} ->
         failed(Rewizard.Regex.source(regex), msg)
@@ -46,14 +46,14 @@ defmodule Rewizard.Cogs.FindAll do
   end
 
   @impl true
-  def command(msg, [strRegex, target]) do
-    reply = find(strRegex, "", target)
+  def command(msg, [str_regex, target]) do
+    reply = find(str_regex, "", target)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 
   @impl true
-  def command(msg, [strRegex, flags, target]) do
-    reply = find(strRegex, flags, target)
+  def command(msg, [str_regex, flags, target]) do
+    reply = find(str_regex, flags, target)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 end

--- a/lib/rewizard/cogs/flag.ex
+++ b/lib/rewizard/cogs/flag.ex
@@ -1,0 +1,83 @@
+defmodule Rewizard.Cogs.Flag do
+  @behaviour Nosedrum.Command
+
+  alias Nostrum.Api
+  import Nostrum.Struct.Embed
+  alias Rewizard.Embeds
+
+  @doc """
+  key => {modifier, description, example usage, example output}
+  """
+  @flags %{
+    "u" =>
+      {"(u)nicode",
+       "Enables Unicode specific patterns like `\\p`. Causes character classes like `\\w`, `\\W`, `\\s`, etc. to match on Unicode.",
+       "`re!find \[[:lower:]]+ u niché`", "`[\"niché\"]`"},
+    "i" =>
+      {"caseless (i)", "adds case insensitivity", "`re!find hello i HELLO`", "`[\"HELLO\"]`"},
+    "s" =>
+      {"dotall (s)", "causes dot to match newlines", "`re!find ... s \"a\nb\"`", "`[\"a\\nb\"]`"},
+    "m" =>
+      {"(m)ultiline",
+       "causes ^ and $ to mark the beginning and end of each line. Use '\\A' and '\\Z' to match beginning and end of the string.",
+       "`re!find ^hello m \"hi\nhello\"`", "`[\"hello\"]`"},
+    "x" =>
+      {"e(x)tended",
+       "whitespace characters are ignored except when in character sets. allow # to delimit comments.",
+       "`re!find \"w as #this is a comment\" x \"was\"`", "`[\"was\"]`"},
+    "f" =>
+      {"(f)irstline", "forces an unanchored pattern to match before or at the first newline",
+       "`re!find abc f \"a\nabc\"`", "No match"},
+    "U" =>
+      {"(U)ngreedy", "inverts the 'greediness' of the regexp", "`re!find hel.*o U hellllooooo`",
+       "[\"hellllo\"]"}
+  }
+
+  @impl true
+  def usage,
+    do: ["flag", "flag <flag>"]
+
+  @impl true
+  def description, do: "Explain and see examples of the different available flags for Rewizard"
+
+  @impl true
+  def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
+
+  def overview do
+    values =
+      Map.values(@flags)
+      |> Enum.map(fn {mod, _desc, _inp, _res} -> mod end)
+
+    Embeds.success("Flag")
+    |> put_description("Use re!flag [char] for more info and examples.")
+    |> put_field("Available Flags", Enum.join(values, ", "))
+  end
+
+  def no_flag(key) do
+    Embeds.fail("Flag - Not Found!")
+    |> put_field("Key", key)
+  end
+
+  def flag({mod, desc, inp, res}) do
+    Embeds.success("Flag - #{mod}")
+    |> put_description(desc)
+    |> put_field("Example Input", inp)
+    |> put_field("Result", res)
+  end
+
+  @impl true
+  def command(msg, []) do
+    Api.create_message!(msg.channel_id, embed: overview())
+  end
+
+  @impl true
+  def command(msg, [key]) do
+    reply =
+      case Map.get(@flags, key) do
+        nil -> no_flag(key)
+        data -> flag(data)
+      end
+
+    Api.create_message!(msg.channel_id, embed: reply)
+  end
+end

--- a/lib/rewizard/cogs/replace.ex
+++ b/lib/rewizard/cogs/replace.ex
@@ -2,11 +2,15 @@ defmodule Rewizard.Cogs.Replace do
   @behaviour Nosedrum.Command
 
   alias Nostrum.Api
-  alias Nostrum.Struct.Embed
   import Nostrum.Struct.Embed
+  alias Rewizard.Embeds
 
   @impl true
-  def usage, do: ["replace <regex> <string> <replacement>"]
+  def usage,
+    do: [
+      "replace <regex> <source> <replacement>",
+      "replace <regex> <flags> <source> <replacement>"
+    ]
 
   @impl true
   def description, do: "Replace the input in the target against this regex"
@@ -14,42 +18,39 @@ defmodule Rewizard.Cogs.Replace do
   @impl true
   def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
 
-  def failed(regex, message) do
-    %Embed{}
-    |> put_title("Rewizard - Replace")
-    |> put_color(0xFF0000)
-    |> put_field("Regex", "`#{regex}`")
-    |> put_field("Error", message)
-  end
-
   def success(regex, target, replacement, result) do
-    %Embed{}
-    |> put_title("Rewizard - Replace")
-    |> put_color(0x008000)
-    |> put_field("Regex", "`#{Regex.source(regex)}`")
+    Embeds.success("Replace")
+    |> Embeds.regex(regex)
     |> put_field("Target", "`#{target}`")
     |> put_field("Replacement", "`#{replacement}`")
     |> put_field("Result", "`#{inspect(result)}`")
   end
 
-  def replace(regex, string, replacement) do
-    success(regex, string, replacement, Regex.replace(regex, string, replacement))
+  def failed(tpl_regex, message) do
+    Embeds.fail("Replace")
+    |> Embeds.regex(tpl_regex)
+    |> put_field("Error", message)
+  end
+
+  def replace(str_regex, flags, source, replacement) do
+    case Rewizard.Regex.compile(str_regex, flags) do
+      {:ok, regex} ->
+        success(regex, source, replacement, Regex.replace(regex, source, replacement))
+
+      {:error, strRegex, msg} ->
+        failed(strRegex, msg)
+    end
   end
 
   @impl true
-  def command(msg, [regex, string, replacement]) do
-    reply =
-      case Regex.compile(regex) do
-        {:ok, regex} ->
-          replace(regex, string, replacement)
+  def command(msg, [str_regex, source, replacement]) do
+    reply = replace(str_regex, "", source, replacement)
+    Api.create_message!(msg.channel_id, embed: reply)
+  end
 
-        {:error, {error, location}} ->
-          failed(
-            regex,
-            "Failed to parse regex at location #{location} with error #{inspect(error)}"
-          )
-      end
-
+  @impl true
+  def command(msg, [str_regex, flags, source, replacement]) do
+    reply = replace(str_regex, flags, source, replacement)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 end

--- a/lib/rewizard/cogs/replace.ex
+++ b/lib/rewizard/cogs/replace.ex
@@ -37,8 +37,8 @@ defmodule Rewizard.Cogs.Replace do
       {:ok, regex} ->
         success(regex, source, replacement, Regex.replace(regex, source, replacement))
 
-      {:error, strRegex, msg} ->
-        failed(strRegex, msg)
+      {:error, str_regex, msg} ->
+        failed(str_regex, msg)
     end
   end
 

--- a/lib/rewizard/cogs/valid.ex
+++ b/lib/rewizard/cogs/valid.ex
@@ -2,8 +2,8 @@ defmodule Rewizard.Cogs.Valid do
   @behaviour Nosedrum.Command
 
   alias Nostrum.Api
-  alias Nostrum.Struct.Embed
   import Nostrum.Struct.Embed
+  alias Rewizard.Embeds
 
   @impl true
   def usage, do: ["valid <regex>", "valid <regex> <flags>"]
@@ -15,19 +15,15 @@ defmodule Rewizard.Cogs.Valid do
   def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
 
   def success(regex) do
-    %Embed{}
-    |> put_title("Rewizard - Valid")
-    |> put_color(0x008000)
-    |> put_field("Regex", Rewizard.Regex.source(regex))
-    |> put_field("Valid", "Yes.")
+    Embeds.success("Valid")
+      |> Embeds.regex(regex)
+      |> put_field("Valid", "Yes.")
   end
 
-  def failed(strRegex, message) do
-    %Embed{}
-    |> put_title("Rewizard - Valid")
-    |> put_color(0xFF0000)
-    |> put_field("Regex", strRegex)
-    |> put_field("Error", message)
+  def failed(tpl_regex, message) do
+    Embeds.fail("Valid")
+      |> Embeds.regex(tpl_regex)
+      |> put_field("Error", message)
   end
 
   def valid(strRegex, flags) do

--- a/lib/rewizard/cogs/valid.ex
+++ b/lib/rewizard/cogs/valid.ex
@@ -6,7 +6,7 @@ defmodule Rewizard.Cogs.Valid do
   import Nostrum.Struct.Embed
 
   @impl true
-  def usage, do: ["valid <regex>"]
+  def usage, do: ["valid <regex>", "valid <regex> <flags>"]
 
   @impl true
   def description, do: "Check if this regex is valid."
@@ -14,36 +14,41 @@ defmodule Rewizard.Cogs.Valid do
   @impl true
   def predicates, do: [&Rewizard.Predicates.correct_channel/1, &Rewizard.Predicates.rate_limit/1]
 
-  def failed(regex, message) do
-    %Embed{}
-    |> put_title("Rewizard - Valid")
-    |> put_color(0xFF0000)
-    |> put_field("Regex", "`#{regex}`")
-    |> put_field("Error", message)
-  end
-
   def success(regex) do
     %Embed{}
     |> put_title("Rewizard - Valid")
     |> put_color(0x008000)
-    |> put_field("Regex", "`#{Regex.source(regex)}`")
+    |> put_field("Regex", Rewizard.Regex.source(regex))
     |> put_field("Valid", "Yes.")
+  end
+
+  def failed(strRegex, message) do
+    %Embed{}
+    |> put_title("Rewizard - Valid")
+    |> put_color(0xFF0000)
+    |> put_field("Regex", strRegex)
+    |> put_field("Error", message)
+  end
+
+  def valid(strRegex, flags) do
+    case Rewizard.Regex.compile(strRegex, flags) do
+      {:ok, regex} ->
+        success(regex)
+
+      {:error, strRegex, msg} ->
+        failed(strRegex, msg)
+    end
   end
 
   @impl true
   def command(msg, [regex]) do
-    reply =
-      case Regex.compile(regex) do
-        {:ok, regex} ->
-          success(regex)
+    reply = valid(regex, "")
+    Api.create_message!(msg.channel_id, embed: reply)
+  end
 
-        {:error, {error, location}} ->
-          failed(
-            regex,
-            "Failed to parse regex at location #{location} with error #{inspect(error)}"
-          )
-      end
-
+  @impl true
+  def command(msg, [regex, flags]) do
+    reply = valid(regex, flags)
     Api.create_message!(msg.channel_id, embed: reply)
   end
 end

--- a/lib/rewizard/cogs/valid.ex
+++ b/lib/rewizard/cogs/valid.ex
@@ -16,23 +16,23 @@ defmodule Rewizard.Cogs.Valid do
 
   def success(regex) do
     Embeds.success("Valid")
-      |> Embeds.regex(regex)
-      |> put_field("Valid", "Yes.")
+    |> Embeds.regex(regex)
+    |> put_field("Valid", "Yes.")
   end
 
   def failed(tpl_regex, message) do
     Embeds.fail("Valid")
-      |> Embeds.regex(tpl_regex)
-      |> put_field("Error", message)
+    |> Embeds.regex(tpl_regex)
+    |> put_field("Error", message)
   end
 
-  def valid(strRegex, flags) do
-    case Rewizard.Regex.compile(strRegex, flags) do
+  def valid(str_regex, flags) do
+    case Rewizard.Regex.compile(str_regex, flags) do
       {:ok, regex} ->
         success(regex)
 
-      {:error, strRegex, msg} ->
-        failed(strRegex, msg)
+      {:error, str_regex, msg} ->
+        failed(str_regex, msg)
     end
   end
 

--- a/lib/rewizard/consumer.ex
+++ b/lib/rewizard/consumer.ex
@@ -17,7 +17,8 @@ defmodule Rewizard.Consumer do
     "split" => Rewizard.Cogs.Split,
     "replace" => Rewizard.Cogs.Replace,
     "help" => Rewizard.Cogs.Help,
-    "info" => Rewizard.Cogs.Info
+    "info" => Rewizard.Cogs.Info,
+    "flag" => Rewizard.Cogs.Flag
   }
 
   def handle_event({:READY, _data, _ws}) do

--- a/lib/rewizard/consumer.ex
+++ b/lib/rewizard/consumer.ex
@@ -36,7 +36,7 @@ defmodule Rewizard.Consumer do
   end
 
   def handle_event({:MESSAGE_CREATE, msg, _ws}) do
-    if msg.content == "<@!#{Me.get().id}>" do
+    if msg.content =~ ~r/<@!?#{Me.get().id}>/ do
       Rewizard.Cogs.Info.command(msg, [])
     else
       CommandInvoker.handle_message(msg, CommandStorage)

--- a/lib/rewizard/embeds.ex
+++ b/lib/rewizard/embeds.ex
@@ -1,0 +1,35 @@
+defmodule Rewizard.Embeds do
+  alias Nostrum.Struct.Embed
+  import Nostrum.Struct.Embed
+
+  @color_fail 0xFF0000
+
+  @color_success 0x008000
+
+  def success(title) do
+    %Embed{}
+    |> put_title("Rewizard - #{title}")
+    |> put_color(@color_success)
+  end
+
+  def fail(title) do
+    %Embed{}
+    |> put_title("Rewizard - #{title}")
+    |> put_color(@color_fail)
+  end
+
+  def regex(embed, {strRegex, nil}) do
+    embed
+      |> put_field("Regex", strRegex)
+  end
+
+  def regex(embed, {strRegex, flags}) do
+    embed
+      |> put_field("Regex", strRegex)
+      |> put_field("Flags", flags)
+  end
+
+  def regex(embed, regex) do
+    regex(embed, Rewizard.Regex.source(regex))
+  end
+end

--- a/lib/rewizard/embeds.ex
+++ b/lib/rewizard/embeds.ex
@@ -18,14 +18,14 @@ defmodule Rewizard.Embeds do
     |> put_color(@color_fail)
   end
 
-  def regex(embed, {strRegex, nil}) do
+  def regex(embed, {str_regex, nil}) do
     embed
-    |> put_field("Regex", strRegex)
+    |> put_field("Regex", str_regex)
   end
 
-  def regex(embed, {strRegex, flags}) do
+  def regex(embed, {str_regex, flags}) do
     embed
-    |> put_field("Regex", strRegex)
+    |> put_field("Regex", str_regex)
     |> put_field("Flags", flags)
   end
 

--- a/lib/rewizard/embeds.ex
+++ b/lib/rewizard/embeds.ex
@@ -20,13 +20,13 @@ defmodule Rewizard.Embeds do
 
   def regex(embed, {strRegex, nil}) do
     embed
-      |> put_field("Regex", strRegex)
+    |> put_field("Regex", strRegex)
   end
 
   def regex(embed, {strRegex, flags}) do
     embed
-      |> put_field("Regex", strRegex)
-      |> put_field("Flags", flags)
+    |> put_field("Regex", strRegex)
+    |> put_field("Flags", flags)
   end
 
   def regex(embed, regex) do

--- a/lib/rewizard/regex.ex
+++ b/lib/rewizard/regex.ex
@@ -1,0 +1,27 @@
+defmodule Rewizard.Regex do
+  def source(regex) do
+    source(regex.source, Regex.opts(regex))
+  end
+
+  def source(strRegex, flags) do
+    if flags == "" do
+      "`/#{strRegex}/`"
+    else
+      "`/#{strRegex}/` `-#{flags}`"
+    end
+  end
+
+  def compile(regex, flags) do
+    case Regex.compile(regex, flags) do
+      {:ok, regex} ->
+        {:ok, regex}
+
+      {:error, {:invalid_option, flag}} ->
+        {:error, source(regex, flag), "Invalid flag provided: #{flag}"}
+
+      {:error, {error, location}} ->
+        {:error, source(regex, flags),
+         "Failed to parse regex at location #{location} with error #{inspect(error)}"}
+    end
+  end
+end

--- a/lib/rewizard/regex.ex
+++ b/lib/rewizard/regex.ex
@@ -25,9 +25,16 @@ defmodule Rewizard.Regex do
     end
   end
 
-  def find(regex, target, captures) do
-    case Regex.run(regex, target, captures) do
+  def find(regex, target) do
+    case Regex.run(regex, target) do
       nil -> {:fail, regex, "Didn't find anything"}
+      result -> {:ok, result}
+    end
+  end
+
+  def find_all(regex, target) do
+    case Regex.scan(regex, target) do
+      [] -> {:fail, regex, "Didn't find anything"}
       result -> {:ok, result}
     end
   end

--- a/lib/rewizard/regex.ex
+++ b/lib/rewizard/regex.ex
@@ -24,4 +24,11 @@ defmodule Rewizard.Regex do
          "Failed to parse regex at location #{location} with error #{inspect(error)}"}
     end
   end
+
+  def find(regex, target, captures) do
+    case Regex.run(regex, target, captures) do
+      nil -> {:fail, regex, "Didn't find anything"}
+      result -> {:ok, result}
+    end
+  end
 end

--- a/lib/rewizard/regex.ex
+++ b/lib/rewizard/regex.ex
@@ -5,9 +5,9 @@ defmodule Rewizard.Regex do
 
   def source(strRegex, flags) do
     if flags == "" do
-      "`/#{strRegex}/`"
+      {"`/#{strRegex}/`", nil}
     else
-      "`/#{strRegex}/` `-#{flags}`"
+      {"`/#{strRegex}/`", "`-#{flags}`"}
     end
   end
 

--- a/lib/rewizard/regex.ex
+++ b/lib/rewizard/regex.ex
@@ -3,11 +3,11 @@ defmodule Rewizard.Regex do
     source(regex.source, Regex.opts(regex))
   end
 
-  def source(strRegex, flags) do
+  def source(str_regex, flags) do
     if flags == "" do
-      {"`/#{strRegex}/`", nil}
+      {"`/#{str_regex}/`", nil}
     else
-      {"`/#{strRegex}/`", "`-#{flags}`"}
+      {"`/#{str_regex}/`", "`-#{flags}`"}
     end
   end
 
@@ -28,6 +28,13 @@ defmodule Rewizard.Regex do
   def find(regex, target, captures) do
     case Regex.run(regex, target, captures) do
       nil -> {:fail, regex, "Didn't find anything"}
+      result -> {:ok, result}
+    end
+  end
+
+  def split(regex, target) do
+    case Regex.split(regex, target) do
+      [] -> {:fail, regex, "Split resulted in an empty list"}
       result -> {:ok, result}
     end
   end


### PR DESCRIPTION
Supported Regex flags:
```
unicode (u) - enables Unicode specific patterns like \p and causes character classes like \w, \W, \s, etc. to also match on Unicode (see examples below in "Character classes"). It expects valid Unicode strings to be given on match
caseless (i) - adds case insensitivity
dotall (s) - causes dot to match newlines and also set newline to anycrlf; the new line setting can be overridden by setting (*CR) or (*LF) or (*CRLF) or (*ANY) according to :re documentation
multiline (m) - causes ^ and $ to mark the beginning and end of each line; use \A and \z to match the end or beginning of the string
extended (x) - whitespace characters are ignored except when escaped and allow # to delimit comments
firstline (f) - forces the unanchored pattern to match before or at the first newline, though the matched text may continue over the newline
ungreedy (U) - inverts the "greediness" of the regexp (the previous r option is deprecated in favor of U)
```

Things are moving to be together in `regex.ex`